### PR TITLE
修复连接管理页面底部没有空出来播放栏从而使滑动有问题,修复已经到底了的多个string配置

### DIFF
--- a/app/src/main/java/cn/xybbz/ui/components/MusicListComponent.kt
+++ b/app/src/main/java/cn/xybbz/ui/components/MusicListComponent.kt
@@ -154,7 +154,7 @@ fun MusicList(
         }
         item {
             LazyLoadingAndStatus(
-                stringResource(R.string.no_more_data),
+                stringResource(R.string.reached_bottom),
                 ifLoading = ifNextPageNumList
             )
         }

--- a/app/src/main/java/cn/xybbz/ui/screens/ConnectionManagement.kt
+++ b/app/src/main/java/cn/xybbz/ui/screens/ConnectionManagement.kt
@@ -35,11 +35,14 @@ import cn.xybbz.R
 import cn.xybbz.common.enums.img
 import cn.xybbz.compositionLocal.LocalNavController
 import cn.xybbz.router.RouterConstants
+import cn.xybbz.ui.components.LazyListComponent
+import cn.xybbz.ui.components.LazyLoadingAndStatus
 import cn.xybbz.ui.components.TopAppBarComponent
 import cn.xybbz.ui.ext.brashColor
 import cn.xybbz.ui.ext.composeClick
 import cn.xybbz.ui.theme.XyTheme
 import cn.xybbz.ui.xy.ItemTrailingArrowRight
+import cn.xybbz.ui.xy.LazyColumnNotComponent
 import cn.xybbz.ui.xy.XyColumnScreen
 import cn.xybbz.viewmodel.ConnectionManagementViewModel
 
@@ -87,7 +90,7 @@ fun ConnectionManagement(
                     )
                 }
             })
-        LazyColumn(
+        LazyColumnNotComponent(
             modifier = Modifier.fillMaxSize(),
             state = lazyListState,
             contentPadding = PaddingValues(8.dp),
@@ -152,6 +155,13 @@ fun ConnectionManagement(
                             }
                         }
                     }
+                )
+            }
+
+            item {
+                LazyLoadingAndStatus(
+                    text = stringResource(R.string.reached_bottom),
+                    ifLoading = false
                 )
             }
         }

--- a/app/src/main/java/cn/xybbz/ui/screens/SearchScreen.kt
+++ b/app/src/main/java/cn/xybbz/ui/screens/SearchScreen.kt
@@ -351,7 +351,7 @@ fun SearchResultScreen(
 
             item {
                 LazyLoadingAndStatus(
-                    text = stringResource(R.string.no_more_data),
+                    text = stringResource(R.string.reached_bottom),
                     ifLoading = false
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,7 +203,6 @@
     <string name="search_box_icon">搜索框图标</string>
     <string name="search_history">搜索历史</string>
     <string name="loading">加载中...</string>
-    <string name="no_more_data">已经到底了</string>
     <!--媒体库选择-->
     <string name="media_library_selection">媒体库选择</string>
     <string name="back_to_connection_info">返回连接信息页面</string>


### PR DESCRIPTION
修复连接管理页面底部没有空出来播放栏从而使滑动有问题
修复已经到底了的多个string配置