### PR TITLE
修改数量统计,限制播放列表加载下一页数据为空后的加载次数

### DIFF
--- a/api/src/main/java/cn/xybbz/api/client/emby/service/EmbyItemApi.kt
+++ b/api/src/main/java/cn/xybbz/api/client/emby/service/EmbyItemApi.kt
@@ -19,6 +19,7 @@
 package cn.xybbz.api.client.emby.service
 
 import cn.xybbz.api.base.BaseApi
+import cn.xybbz.api.client.jellyfin.data.CountsResponse
 import cn.xybbz.api.client.jellyfin.data.ItemResponse
 import cn.xybbz.api.client.jellyfin.data.Response
 import retrofit2.http.GET
@@ -54,4 +55,12 @@ interface EmbyItemApi : BaseApi {
         @Query("Fields") fields: String? = null
     ): Response<ItemResponse>
 
+    /**
+     * 获得数量统计
+     */
+    @GET("/emby/Items/Counts")
+    suspend fun getCounts(
+        @Query("userId") userId: String? = null,
+        @Query("isFavorite") isFavorite: Boolean? = null
+    ): CountsResponse
 }

--- a/api/src/main/java/cn/xybbz/api/client/jellyfin/data/CountsResponse.kt
+++ b/api/src/main/java/cn/xybbz/api/client/jellyfin/data/CountsResponse.kt
@@ -1,0 +1,50 @@
+/*
+ *   XyMusic
+ *   Copyright (C) 2023 xianyvbang
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package cn.xybbz.api.client.jellyfin.data
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class CountsResponse(
+    @param:Json(name = "MovieCount")
+    val movieCount: Int,
+    @param:Json(name = "SeriesCount")
+    val seriesCount: Int,
+    @param:Json(name = "EpisodeCount")
+    val episodeCount: Int,
+    @param:Json(name = "ArtistCount")
+    val artistCount: Int,
+    @param:Json(name = "ProgramCount")
+    val programCount: Int,
+    @param:Json(name = "TrailerCount")
+    val trailerCount: Int,
+    @param:Json(name = "SongCount")
+    val songCount: Int,
+    @param:Json(name = "AlbumCount")
+    val albumCount: Int,
+    @param:Json(name = "MusicVideoCount")
+    val musicVideoCount: Int,
+    @param:Json(name = "BoxSetCount")
+    val boxSetCount: Int,
+    @param:Json(name = "BookCount")
+    val bookCount: Int,
+    @param:Json(name = "ItemCount")
+    val itemCount: Int
+)

--- a/api/src/main/java/cn/xybbz/api/client/jellyfin/service/ItemApi.kt
+++ b/api/src/main/java/cn/xybbz/api/client/jellyfin/service/ItemApi.kt
@@ -19,6 +19,7 @@
 package cn.xybbz.api.client.jellyfin.service
 
 import cn.xybbz.api.base.BaseApi
+import cn.xybbz.api.client.jellyfin.data.CountsResponse
 import cn.xybbz.api.client.jellyfin.data.ItemResponse
 import cn.xybbz.api.client.jellyfin.data.Response
 import retrofit2.http.GET
@@ -51,4 +52,12 @@ interface ItemApi : BaseApi {
         @Query("Fields") fields: String? = null
     ): Response<ItemResponse>
 
+    /**
+     * 获得数量统计
+     */
+    @GET("/Items/Counts")
+    suspend fun getCounts(
+        @Query("userId") userId: String? = null,
+        @Query("isFavorite") isFavorite: Boolean? = null
+    ): CountsResponse
 }

--- a/app/src/main/java/cn/xybbz/common/music/MusicController.kt
+++ b/app/src/main/java/cn/xybbz/common/music/MusicController.kt
@@ -135,6 +135,8 @@ class MusicController(
 
     var ifNextPage = true
 
+    var ifGetNextPageMusicDataIsNullCount:Int = 0
+
     //事件发送流
     private val _events = MutableSharedFlow<PlayerEvent>(
         replay = 0,
@@ -575,7 +577,7 @@ class MusicController(
         playDataType = musicPlayTypeEnum
 
         Log.i("music", "初始化音乐列表开始播放")
-        updateIfNextPage(true)
+        updateRestartCount()
         originMusicList = emptyList()
 
         if (musicCurrentPositionMapData != null) {
@@ -837,7 +839,27 @@ class MusicController(
         this.duration = duration
     }
 
-    fun updateIfNextPage(ifNextPage: Boolean){
+
+    /**
+     * 更新获取下一页音乐数据为空的次数
+     */
+    @Synchronized
+    fun updateIfGetNextPageMusicDataIsNullCount(count: Int){
+        this.ifGetNextPageMusicDataIsNullCount += count
+        if (this.ifGetNextPageMusicDataIsNullCount >= 3){
+            updateIfNextPage(false)
+        }
+    }
+
+    fun updateRestartCount(){
+        this.ifGetNextPageMusicDataIsNullCount = 0
+        updateIfNextPage(true)
+    }
+
+    /**
+     * 更新是否可以加载下一页音乐数据
+     */
+    private fun updateIfNextPage(ifNextPage: Boolean){
         this.ifNextPage = ifNextPage
     }
 

--- a/app/src/main/java/cn/xybbz/common/music/MusicController.kt
+++ b/app/src/main/java/cn/xybbz/common/music/MusicController.kt
@@ -133,6 +133,8 @@ class MusicController(
     var playType by mutableStateOf(PlayerTypeEnum.SEQUENTIAL_PLAYBACK)
         private set
 
+    var ifNextPage = true
+
     //事件发送流
     private val _events = MutableSharedFlow<PlayerEvent>(
         replay = 0,
@@ -246,7 +248,7 @@ class MusicController(
             curOriginIndex = mediaController?.currentMediaItemIndex ?: 0
         },
         onOriginMusicListIsNotEmptyAndIndexEnd = {
-            originMusicList.isNotEmpty() && curOriginIndex >= originMusicList.size - 1
+            originMusicList.isNotEmpty() && curOriginIndex >= originMusicList.size - 1 && ifNextPage
         },
         onPageNumber = { pageNum },
         onUpdateDuration = {
@@ -573,7 +575,7 @@ class MusicController(
         playDataType = musicPlayTypeEnum
 
         Log.i("music", "初始化音乐列表开始播放")
-
+        updateIfNextPage(true)
         originMusicList = emptyList()
 
         if (musicCurrentPositionMapData != null) {
@@ -586,7 +588,7 @@ class MusicController(
         val tmpList = mutableListOf<XyPlayMusic>()
         tmpList.addAll(musicDataList)
         originMusicList = tmpList
-        this.pageNum = pageNum
+        setPageNumData(pageNum)
         this.pageSize = pageSize
 
         if (musicDataList.isNotEmpty()) {
@@ -749,7 +751,7 @@ class MusicController(
         updateState(PlayStateEnum.None)
         headTime = Constants.ZERO.toLong()
         endTime = Constants.ZERO.toLong()
-        pageNum = Constants.ZERO
+        setPageNumData(Constants.ZERO)
         pageSize = Constants.ZERO
         fadeController.release()
     }
@@ -835,6 +837,10 @@ class MusicController(
         this.duration = duration
     }
 
+    fun updateIfNextPage(ifNextPage: Boolean){
+        this.ifNextPage = ifNextPage
+    }
+
     fun reportedPlayEvent() {
         musicInfo?.let {
             scope.launch {
@@ -863,7 +869,7 @@ class MusicController(
         updateState(PlayStateEnum.None)
         headTime = Constants.ZERO.toLong()
         endTime = Constants.ZERO.toLong()
-        pageNum = Constants.ZERO
+        setPageNumData(Constants.ZERO)
         pageSize = Constants.ZERO
         fadeController.close()
         mediaController?.release()

--- a/app/src/main/java/cn/xybbz/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/cn/xybbz/viewmodel/MainViewModel.kt
@@ -403,13 +403,13 @@ class MainViewModel @Inject constructor(
             val newMusicList = musicPlayContext.musicPlayData?.onNextMusicList?.invoke(newPageNum)
             if (!newMusicList.isNullOrEmpty()) {
                 musicController.setPageNumData(newPageNum)
-                if (newMusicList.isNotEmpty())
-                    musicController.addMusicList(
-                        newMusicList,
-                        musicPlayContext.musicPlayData?.onMusicPlayParameter?.artistId
-                    )
+                musicController.addMusicList(
+                    newMusicList,
+                    musicPlayContext.musicPlayData?.onMusicPlayParameter?.artistId
+                )
+                musicController.updateRestartCount()
             }else {
-                musicController.updateIfNextPage(false)
+                musicController.updateIfGetNextPageMusicDataIsNullCount(1)
             }
         }.invokeOnCompletion { ifNextPageNumList = false }
     }

--- a/app/src/main/java/cn/xybbz/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/cn/xybbz/viewmodel/MainViewModel.kt
@@ -408,6 +408,8 @@ class MainViewModel @Inject constructor(
                         newMusicList,
                         musicPlayContext.musicPlayData?.onMusicPlayParameter?.artistId
                     )
+            }else {
+                musicController.updateIfNextPage(false)
             }
         }.invokeOnCompletion { ifNextPageNumList = false }
     }


### PR DESCRIPTION
修改jellyfin和emby的数据数量统计方式
完善播放列表加载下一页数据的判断,三次为空的时候就不再获取下一页